### PR TITLE
Python-3.13 on CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.13", "3.13t"]
+        python-version: ["3.8", "3.13", "3.13t"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: Quansight-Labs/setup-python@v5
+        uses: Quansight-Labs/setup-python@v5  # until https://github.com/actions/setup-python/issues/771 is resolved
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.13", "3.13t"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,26 +3,16 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+from datetime import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = 'printree'
-copyright = '2020, Christian López Barrón'
+copyright = f'{datetime.now().year}, Christian López Barrón'
 author = 'Christian López Barrón'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.0'
+release = '0.2.1'
 
 
 # -- General configuration ---------------------------------------------------
@@ -30,22 +20,19 @@ release = '0.1.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx',
-              # 'sphinx.ext.todo',
-              # 'sphinx.ext.coverage',
-              # 'sphinx.ext.imgmath',
-              # 'sphinx.ext.ifconfig',
-              'sphinx.ext.viewcode',
-              # 'sphinx.ext.githubpages',
-              'sphinx.ext.graphviz',
-              'sphinx.ext.inheritance_diagram',
-              'm2r2',
-              'sphinx_autodoc_typehints']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.inheritance_diagram',
+    'myst_parser',
+    'sphinx_autodoc_typehints',
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -64,6 +51,8 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
-intersphinx_mapping = {'https://docs.python.org/3': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,9 @@
    :maxdepth: 2
    :caption: Contents:
 
-.. mdinclude:: ../../README.md
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+
 
 Module contents
 ---------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,4 @@ classifiers =
 packages = find:
 
 [options.extras_require]
-docs = sphinx_autodoc_typehints; sphinx_rtd_theme; m2r2
+docs = sphinx; sphinx_autodoc_typehints; sphinx_rtd_theme; myst-parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,12 +9,12 @@ author_email = chris.gfz@gmail.com
 author = Christian López Barrón
 url = https://github.com/chrizzFTD/printree
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 packages = find:


### PR DESCRIPTION
- CI python range is now 3.7 -> 3.13
- Including free threaded test for 3.13
- Replaced m2r2 with myst_parser
- Fix a deprecated intersphinx mapping setup